### PR TITLE
Fix PNG file sorting

### DIFF
--- a/YDPNGtoPDFApp/ContentView.swift
+++ b/YDPNGtoPDFApp/ContentView.swift
@@ -9,10 +9,6 @@ import SwiftUI
 import PDFKit
 import UniformTypeIdentifiers
 
-import SwiftUI
-import PDFKit
-import UniformTypeIdentifiers
-
 struct ContentView: View {
     @State private var statusMessage = "フォルダを選択してPNG→PDF変換"
 
@@ -46,7 +42,9 @@ struct ContentView: View {
                         return false
                     }
                     return type == .png
-                }.sorted { $0.lastPathComponent < $1.lastPathComponent } // ファイル名順にソート
+                }.sorted { a, b in
+                    a.lastPathComponent.localizedStandardCompare(b.lastPathComponent) == .orderedAscending
+                } // ファイル名順にソート
 
                 guard !pngFiles.isEmpty else {
                     statusMessage = "PNGファイルが見つかりません"


### PR DESCRIPTION
## Summary
- dedupe imports in ContentView
- ensure PNG files sort naturally when building PDFs

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686bd005fd488331a80cb0fdb09b43df