### PR TITLE
対応画像フォーマットをPNG+JPEGに拡充し、多言語化の土台を追加

### DIFF
--- a/YDPNGtoPDFApp/ContentView.swift
+++ b/YDPNGtoPDFApp/ContentView.swift
@@ -10,7 +10,7 @@ import PDFKit
 import UniformTypeIdentifiers
 
 struct ContentView: View {
-    @State private var statusMessage = "フォルダを選択してPNG→PDF変換"
+    @State private var statusMessage = ContentView.localized("status.initial", "フォルダを選択して画像をPDFに変換")
     @State private var isProcessing = false
 
     var body: some View {
@@ -37,7 +37,7 @@ struct ContentView: View {
         openPanel.canChooseDirectories = true
         openPanel.canChooseFiles = false
         openPanel.allowsMultipleSelection = false
-        openPanel.prompt = "フォルダを選択"
+        openPanel.prompt = Self.localized("picker.selectFolderPrompt", "フォルダを選択")
 
         guard openPanel.runModal() == .OK, let folderURL = openPanel.url else { return }
 
@@ -46,22 +46,22 @@ struct ContentView: View {
 
         if FileManager.default.fileExists(atPath: outputURL.path) {
             let alert = NSAlert()
-            alert.messageText = "\(outputPDFName) は既に存在します"
-            alert.informativeText = "上書きしてもよろしいですか?"
+            alert.messageText = String(format: Self.localized("alert.overwriteTitle", "%@ は既に存在します"), outputPDFName)
+            alert.informativeText = Self.localized("alert.overwriteMessage", "上書きしてもよろしいですか?")
             alert.alertStyle = .warning
-            alert.addButton(withTitle: "上書き")
-            alert.addButton(withTitle: "キャンセル")
+            alert.addButton(withTitle: Self.localized("alert.overwriteConfirm", "上書き"))
+            alert.addButton(withTitle: Self.localized("alert.cancel", "キャンセル"))
             guard alert.runModal() == .alertFirstButtonReturn else {
-                statusMessage = "キャンセルしました"
+                statusMessage = Self.localized("status.cancelled", "キャンセルしました")
                 return
             }
         }
 
         isProcessing = true
-        statusMessage = "変換中..."
+        statusMessage = Self.localized("status.converting", "変換中...")
 
         Task.detached(priority: .userInitiated) {
-            let result = Self.convertPNGsToPDF(folderURL: folderURL, outputURL: outputURL)
+            let result = Self.convertImagesToPDF(folderURL: folderURL, outputURL: outputURL)
             await MainActor.run {
                 isProcessing = false
                 statusMessage = result
@@ -73,31 +73,34 @@ struct ContentView: View {
         urls.sorted { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }
     }
 
-    static func convertPNGsToPDF(folderURL: URL, outputURL: URL) -> String {
+    /// フォルダ内から変換対象として拾い上げる画像フォーマット。今後の拡充はここに追加する。
+    static let supportedImageTypes: Set<UTType> = [.png, .jpeg]
+
+    static func convertImagesToPDF(folderURL: URL, outputURL: URL) -> String {
         let fileManager = FileManager.default
         let contents: [URL]
         do {
             contents = try fileManager.contentsOfDirectory(at: folderURL, includingPropertiesForKeys: [.contentTypeKey])
         } catch {
-            return "エラー: \(error.localizedDescription)"
+            return String(format: localized("status.error", "エラー: %@"), error.localizedDescription)
         }
 
-        let pngFiles = naturalSorted(contents.filter { url in
+        let imageFiles = naturalSorted(contents.filter { url in
             if let values = try? url.resourceValues(forKeys: [.contentTypeKey]),
                let type = values.contentType {
-                return type == .png
+                return supportedImageTypes.contains(type)
             }
             return false
         })
 
-        guard !pngFiles.isEmpty else {
-            return "PNGファイルが見つかりません"
+        guard !imageFiles.isEmpty else {
+            return localized("status.noImagesFound", "画像ファイルが見つかりません")
         }
 
         let pdfDocument = PDFDocument()
         var failedFileNames: [String] = []
 
-        for url in pngFiles {
+        for url in imageFiles {
             if let image = NSImage(contentsOf: url), let page = PDFPage(image: image) {
                 pdfDocument.insert(page, at: pdfDocument.pageCount)
             } else {
@@ -106,18 +109,30 @@ struct ContentView: View {
         }
 
         guard pdfDocument.pageCount > 0 else {
-            return "PDFに変換できる画像がありませんでした"
+            return localized("status.noConvertibleImages", "PDFに変換できる画像がありませんでした")
         }
 
         guard pdfDocument.write(to: outputURL) else {
-            return "PDFの作成に失敗しました"
+            return localized("status.writeFailed", "PDFの作成に失敗しました")
         }
 
-        var message = "PDFを作成しました: \(outputURL.lastPathComponent)(\(pdfDocument.pageCount)ページ)"
+        var message = String(
+            format: localized("status.pdfCreated", "PDFを作成しました: %@(%@ページ)"),
+            outputURL.lastPathComponent,
+            "\(pdfDocument.pageCount)"
+        )
         if !failedFileNames.isEmpty {
-            message += "\n読み込めなかったファイル: \(failedFileNames.joined(separator: ", "))"
+            message += String(
+                format: localized("status.failedFiles", "\n読み込めなかったファイル: %@"),
+                failedFileNames.joined(separator: ", ")
+            )
         }
         return message
+    }
+
+    /// String Catalog(Localizable.xcstrings)からキーを引く。未登録キーの場合はdefaultValueをそのまま表示する。
+    static func localized(_ key: String, _ defaultValue: String) -> String {
+        NSLocalizedString(key, bundle: .main, value: defaultValue, comment: "")
     }
 }
 

--- a/YDPNGtoPDFApp/Localizable.xcstrings
+++ b/YDPNGtoPDFApp/Localizable.xcstrings
@@ -1,0 +1,175 @@
+{
+  "sourceLanguage" : "ja",
+  "strings" : {
+    "alert.cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        }
+      }
+    },
+    "alert.overwriteConfirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上書き"
+          }
+        }
+      }
+    },
+    "alert.overwriteMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上書きしてもよろしいですか?"
+          }
+        }
+      }
+    },
+    "alert.overwriteTitle" : {
+      "comment" : "%@ = 出力ファイル名",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ は既に存在します"
+          }
+        }
+      }
+    },
+    "picker.selectFolderPrompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダを選択"
+          }
+        }
+      }
+    },
+    "status.cancelled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセルしました"
+          }
+        }
+      }
+    },
+    "status.converting" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変換中..."
+          }
+        }
+      }
+    },
+    "status.error" : {
+      "comment" : "%@ = エラーの説明文",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー: %@"
+          }
+        }
+      }
+    },
+    "status.failedFiles" : {
+      "comment" : "%@ = 読み込みに失敗したファイル名のカンマ区切りリスト",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\n読み込めなかったファイル: %@"
+          }
+        }
+      }
+    },
+    "status.initial" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダを選択して画像をPDFに変換"
+          }
+        }
+      }
+    },
+    "status.noConvertibleImages" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDFに変換できる画像がありませんでした"
+          }
+        }
+      }
+    },
+    "status.noImagesFound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像ファイルが見つかりません"
+          }
+        }
+      }
+    },
+    "status.pdfCreated" : {
+      "comment" : "1つ目の%@ = 出力ファイル名, 2つ目の%@ = ページ数",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDFを作成しました: %@(%@ページ)"
+          }
+        }
+      }
+    },
+    "status.writeFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDFの作成に失敗しました"
+          }
+        }
+      }
+    },
+    "フォルダを選んでPDFを作成" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダを選んでPDFを作成"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/YDPNGtoPDFAppTests/YDPNGtoPDFAppTests.swift
+++ b/YDPNGtoPDFAppTests/YDPNGtoPDFAppTests.swift
@@ -21,17 +21,17 @@ struct YDPNGtoPDFAppTests {
         #expect(sorted == ["page1.png", "page2.png", "page10.png", "page20.png"])
     }
 
-    @Test func convertPNGsToPDFReturnsMessageWhenFolderHasNoPNGs() async throws {
+    @Test func convertImagesToPDFReturnsMessageWhenFolderHasNoImages() async throws {
         let folderURL = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: folderURL) }
 
         let outputURL = folderURL.appendingPathComponent("output.pdf")
-        let result = ContentView.convertPNGsToPDF(folderURL: folderURL, outputURL: outputURL)
+        let result = ContentView.convertImagesToPDF(folderURL: folderURL, outputURL: outputURL)
 
-        #expect(result == "PNGファイルが見つかりません")
+        #expect(result == "画像ファイルが見つかりません")
     }
 
-    @Test func convertPNGsToPDFCombinesImagesInNaturalOrder() async throws {
+    @Test func convertImagesToPDFCombinesImagesInNaturalOrder() async throws {
         let folderURL = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: folderURL) }
 
@@ -40,14 +40,29 @@ struct YDPNGtoPDFAppTests {
         }
 
         let outputURL = folderURL.appendingPathComponent("output.pdf")
-        let result = ContentView.convertPNGsToPDF(folderURL: folderURL, outputURL: outputURL)
+        let result = ContentView.convertImagesToPDF(folderURL: folderURL, outputURL: outputURL)
 
         #expect(result.contains("3ページ"))
         let pdfDocument = try #require(PDFDocument(url: outputURL))
         #expect(pdfDocument.pageCount == 3)
     }
 
-    @Test func convertPNGsToPDFReportsFilesThatFailToDecode() async throws {
+    @Test func convertImagesToPDFIncludesJPEGsAlongsidePNGs() async throws {
+        let folderURL = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        try writeSolidColorPNG(to: folderURL.appendingPathComponent("page1.png"))
+        try writeSolidColorJPEG(to: folderURL.appendingPathComponent("page2.jpg"))
+
+        let outputURL = folderURL.appendingPathComponent("output.pdf")
+        let result = ContentView.convertImagesToPDF(folderURL: folderURL, outputURL: outputURL)
+
+        #expect(result.contains("2ページ"))
+        let pdfDocument = try #require(PDFDocument(url: outputURL))
+        #expect(pdfDocument.pageCount == 2)
+    }
+
+    @Test func convertImagesToPDFReportsFilesThatFailToDecode() async throws {
         let folderURL = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: folderURL) }
 
@@ -55,7 +70,7 @@ struct YDPNGtoPDFAppTests {
         try Data().write(to: folderURL.appendingPathComponent("broken.png"))
 
         let outputURL = folderURL.appendingPathComponent("output.pdf")
-        let result = ContentView.convertPNGsToPDF(folderURL: folderURL, outputURL: outputURL)
+        let result = ContentView.convertImagesToPDF(folderURL: folderURL, outputURL: outputURL)
 
         #expect(result.contains("1ページ"))
         #expect(result.contains("broken.png"))
@@ -71,16 +86,26 @@ private func makeTempDirectory() throws -> URL {
 }
 
 private func writeSolidColorPNG(to url: URL) throws {
+    guard let pngData = solidColorBitmap().representation(using: .png, properties: [:]) else {
+        throw CocoaError(.fileWriteUnknown)
+    }
+    try pngData.write(to: url)
+}
+
+private func writeSolidColorJPEG(to url: URL) throws {
+    guard let jpegData = solidColorBitmap().representation(using: .jpeg, properties: [:]) else {
+        throw CocoaError(.fileWriteUnknown)
+    }
+    try jpegData.write(to: url)
+}
+
+private func solidColorBitmap() -> NSBitmapImageRep {
     let image = NSImage(size: NSSize(width: 4, height: 4))
     image.lockFocus()
     NSColor.red.setFill()
     NSRect(x: 0, y: 0, width: 4, height: 4).fill()
     image.unlockFocus()
 
-    guard let tiffData = image.tiffRepresentation,
-          let bitmap = NSBitmapImageRep(data: tiffData),
-          let pngData = bitmap.representation(using: .png, properties: [:]) else {
-        throw CocoaError(.fileWriteUnknown)
-    }
-    try pngData.write(to: url)
+    let tiffData = image.tiffRepresentation!
+    return NSBitmapImageRep(data: tiffData)!
 }


### PR DESCRIPTION
## Summary
- 対応画像フォーマットをPNGのみからPNG+JPEGに拡充(`supportedImageTypes`)。自然順ソートは混在フォルダでも維持される
- 多言語化の土台として `Localizable.xcstrings`(String Catalog, sourceLanguage: ja)を追加し、全UI文言・ステータスメッセージ・アラート文言を `NSLocalizedString` 経由に変更。翻訳は現状日本語のみ維持し、将来の翻訳追加を容易にする
- `convertPNGsToPDF` を `convertImagesToPDF` にリネームし、テストを追随・拡充(PNG+JPEG混在ケースを追加)

## Test plan
- [x] `xcodebuild ... test` でユニットテスト5件成功(自然順ソート、画像なし、PNG+JPEG混在、正常変換、デコード失敗検出)
- [x] 実機でPNG+JPEG混在フォルダ(page1.png/page2.jpg/page10.png)を変換し、赤→緑→青の順で3ページPDFが生成されることを確認
- [x] ステータス表示の日本語文言(String Catalog経由)が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)